### PR TITLE
Use correct logging method name when using block form

### DIFF
--- a/profanity.rb
+++ b/profanity.rb
@@ -2124,7 +2124,7 @@ Thread.new {
 		command_window.noutrefresh
 		Curses.doupdate
 	rescue
-		Profanity.log { |f| f.puts $!; f.puts $!.backtrace[0...4] }
+		Profanity.log_file { |f| f.puts $!; f.puts $!.backtrace[0...4] }
 		exit
 	end
 }
@@ -2154,7 +2154,7 @@ begin
 		end
 	}
 rescue
-	Profanity.log { |f| f.puts $!; f.puts $!.backtrace[0...4] }
+	Profanity.log_file { |f| f.puts $!; f.puts $!.backtrace[0...4] }
 ensure
 	server.close rescue()
 	Curses.close_screen

--- a/profanity.rb
+++ b/profanity.rb
@@ -1959,12 +1959,6 @@ Thread.new {
 								end
 							end
 						end
-					elsif xml =~ /^<progressBar id='(.*?)' value='[0-9]+' text='\1 (\-?[0-9]+)\/([0-9]+)'/
-						if window = progress_handler[$1]
-							if window.update($2.to_i, $3.to_i)
-								need_update = true
-							end
-						end
 					elsif xml =~ /^<progressBar id='encumlevel' value='([0-9]+)' text='(.*?)'/
 						if window = progress_handler['encumbrance']
 							if $2 == 'Overloaded'
@@ -1992,6 +1986,12 @@ Thread.new {
 								value = $1.to_i
 							end
 							if window.update(value, 110)
+								need_update = true
+							end
+						end
+					elsif xml =~ /^<progressBar id='(.*?)' value='[0-9]+' text='.*?\s+(\-?[0-9]+)\/([0-9]+)'/
+						if window = progress_handler[$1]
+							if window.update($2.to_i, $3.to_i)
 								need_update = true
 							end
 						end


### PR DESCRIPTION
This caused the profanity process to always exit with a non-zero status.