### PR TITLE
Untaint of Title Variable

### DIFF
--- a/profanity.rb
+++ b/profanity.rb
@@ -1613,11 +1613,17 @@ Thread.new {
 							end
 						end
 					elsif xml =~ /^<LaunchURL src="([^"]+)"/
-						url = "\"https://www.play.net#{$1}\""
-						# assume linux if not mac
-						cmd = RUBY_PLATFORM =~ /darwin/ ? "open" : "google-chrome"
-						system("#{cmd} #{url} >/dev/null 2>&1 &")
-					else
+            url = "\"https://www.play.net#{$1}\""
+            @url = url
+            @url.untaint
+            if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+              system "start #{url} >/dev/null 2>&1 &"
+            elsif RbConfig::CONFIG['host_os'] =~ /darwin/
+              system "open #{url} >/dev/null 2>&1 &"
+            elsif RbConfig::CONFIG['host_os'] =~ /linux|bsd/
+              system "xdg-open #{url} >/dev/null 2>&1 &"
+            end
+          else
 						nil
 					end
 				end

--- a/profanity.rb
+++ b/profanity.rb
@@ -70,7 +70,8 @@ module Profanity
 
 	def self.set_terminal_title(title)
 		return if @title.eql?(title) # noop
-		@title = title	
+		@title = title
+		@title.untaint
 		system("printf \"\033]0;#{title}\007\"")
 		Process.setproctitle(title)
 	end


### PR DESCRIPTION
Resolves tainted variable issue and allows the title to properly be displayed without throwing a SecurityError
This resolves Issue #11 